### PR TITLE
Sitellite app: Util: Security patch

### DIFF
--- a/inc/app/sitellite/boxes/util/access.php
+++ b/inc/app/sitellite/boxes/util/access.php
@@ -60,11 +60,11 @@
 ;   "contains '@', length '3+'"
 ;
 
-sitellite_access = public
+sitellite_access = master
 sitellite_status = approved
 sitellite_action = on
 
 ;
 ; THE END
 ;
-; DO NOT ALTER THIS LINE, IT IS HERE FOR SECURITY REASONS */ ?>
+; DO NOT ALTER THIS LINE, IT IS HERE FOR SECURITY REASONS */

--- a/inc/app/sitellite/boxes/util/pdfmaker/access.php
+++ b/inc/app/sitellite/boxes/util/pdfmaker/access.php
@@ -1,3 +1,7 @@
-sitellite_access = public
+; <?php /*
+
+sitellite_access = master
 sitellite_status = approved
 sitellite_action = on
+
+; */

--- a/inc/app/sitellite/boxes/util/snippets/access.php
+++ b/inc/app/sitellite/boxes/util/snippets/access.php
@@ -1,4 +1,8 @@
-sitellite_access = public
+; <?php /*
+
+sitellite_access = master
 sitellite_action = on
 sitellite_status = approved
 sitellite_inline = on
+
+; */


### PR DESCRIPTION
Sitellite app: Util: phpinfo, pathinfo, pdfmaker, snippets and textile boxes access level set to master.
Running of phpinfo, pathinfo and textile boxes by anonymous is not a good idea (configuration exposing and HTML code rendering).
snippets may be used for getting data from sitellite_property_set by anonymous. 