### PR TITLE
[L10n] Update th.xml: "Thailand": "ประเทศไทย" -> "ไทย"

### DIFF
--- a/inc/app/sitesearch/lib/Zend/Locale/Data/th.xml
+++ b/inc/app/sitesearch/lib/Zend/Locale/Data/th.xml
@@ -831,7 +831,7 @@
             <territory type="TD">ชาด</territory>
             <territory type="TF">อาณาเขตทางใต้ของฝรั่งเศส</territory>
             <territory type="TG">โตโก</territory>
-            <territory type="TH">ประเทศไทย</territory>
+            <territory type="TH">ไทย</territory>
             <territory type="TJ">ทาจิกิสถาน</territory>
             <territory type="TK">โทกิโล</territory>
             <territory type="TL">ติมอร์ตะวันออก</territory>


### PR DESCRIPTION
Remove "ประเทศ" ("country") prefix from the Thai translation of "Thailand", to make it consistent with other countries' Thai translation in the same file which don't have such prefix.

This will make it easier for the user to find the countries.